### PR TITLE
added timeout (5s) to httpRequest

### DIFF
--- a/others/Paywall redirect to Archive.today.user.js
+++ b/others/Paywall redirect to Archive.today.user.js
@@ -70,10 +70,12 @@
       GM.xmlHttpRequest({
         url: `https://${hostname}/`,
         method: 'GET',
+        timeout: 5000,
         headers: {
           Range: 'bytes=0-63'
         },
         onload: onResponse,
+        ontimeout: onResponse,
         onerror: onResponse
       })
     })


### PR DESCRIPTION
Hi,

with this timeout, the probe of dead or nonworking archive-domains works way faster ...

